### PR TITLE
Add check for nil

### DIFF
--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -19,7 +19,10 @@ func Exists(name string) bool {
 	if err == nil {
 		return true
 	}
-	if os.IsNotExist(err){
+	if os.IsNotExist(err) {
+		return false
+	}
+	if i == nil {
 		return false
 	}
 	return i.IsDir()


### PR DESCRIPTION
It is possible that `os.Stat()` returns `nil`, therefore there should be a check before. Had this issue yesterday and was able to fix it with the provided check.